### PR TITLE
update dependency for magento 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
   ],
   "require": {
     "php": "~5.5.0|~5.6.0|~7.0.0",
-    "magento/module-ui": "100.0.*",
-    "magento/framework": "100.0.*",
-    "magento/module-cms": "100.0.*"
+    "magento/module-ui": "100.1.*",
+    "magento/framework": "100.1.*",
+    "magento/module-cms": "101.0.*"
   },
   "type": "magento2-module",
   "autoload": {


### PR DESCRIPTION
doesn't install through composer right now if using magento 2.1. 